### PR TITLE
Fixed include path for blitzlib

### DIFF
--- a/src/main/include/Autonomous.hpp
+++ b/src/main/include/Autonomous.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <frc/WPIlib.h> 
-#include <BlitzLib/BlitzLib.hpp>
+#include <blitzLib/BlitzLib.hpp>
 
 namespace Blitz
 {

--- a/src/main/include/Climber.hpp
+++ b/src/main/include/Climber.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <frc/WPILib.h>
-#include <BlitzLib/BlitzLib.hpp>
+#include <blitzLib/BlitzLib.hpp>
 #include <ctre/Phoenix.h>
 
 namespace Blitz

--- a/src/main/include/Manipulator.hpp
+++ b/src/main/include/Manipulator.hpp
@@ -20,7 +20,7 @@ enum wristDegrees
 
 #include "frc/WPILib.h"
 #include "ctre/Phoenix.h"
-#include <BlitzLib/BlitzLib.hpp>
+#include <blitzLib/BlitzLib.hpp>
 
 namespace Blitz
 {

--- a/src/main/include/Robot.h
+++ b/src/main/include/Robot.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <frc/WPILib.h>
-#include <BlitzLib/BlitzLib.hpp>
+#include <blitzLib/BlitzLib.hpp>
 #include <ctre/Phoenix.h>
 #include <Manipulator.hpp>
 #include <Math.h>


### PR DESCRIPTION
Something was capitalized that shouldn't be and that apparently causes problems (even though other people have been able to build it?)

I'm not exactly sure why my computer complains about it but, it shouldn't break everything as far as I know. Then again, it's me so who knows?...